### PR TITLE
Switch to lcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
   - 0.12
   - "iojs"
 script: "npm run travis"
-after_script: "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
+after_script: "cat ./coverage/lcov.lcov | ./node_modules/.bin/coveralls"


### PR DESCRIPTION
JSON support is having issues and I'm working on getting better support for it. Meanwhile, we can stick with `lcov` for accurate reporting.

Thanks!
